### PR TITLE
Distance checker

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -114,6 +114,11 @@ AddEventHandler('bcc-farming:IsPLayerNearTownCheck', function(_source, v)
             end
         end
     end
+    local nearotherplant = IsAnyPlantPropNearPed()
+    Wait(100)
+    if nearotherplant then
+        VORPcore.NotifyRightTip(Config.Language.TooCloseToPlant, 4000) return
+    end
     if isoutsideoftown == true then --after all the above code runs if outside of town = true then
         TriggerServerEvent('bcc-farming:PlayerNotNearTown', _source, v, isoutsideoftown) --trigger server event to continue planting
     end

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -106,3 +106,15 @@ AddEventHandler('bcc-farming:WaitUntilHarvest', function(blip, timer, reward, am
         end
     end
 end)
+
+--function to see if player is near any placed objects listed in config
+function IsAnyPlantPropNearPed()
+    for k,v in pairs(Config.Farming) do
+        local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 2.5, 0))
+        local Entity = (GetClosestObjectOfType(x,y,z, 2.5, GetHashKey(v.PlantProp), false, false, false))
+        if Entity ~= 0 then
+            return true
+        end
+    end
+    return false
+end

--- a/config.lua
+++ b/config.lua
@@ -65,7 +65,8 @@ Config.Language = {
     CropWatered = 'You watered the crop',
     Notinwater = 'You are not near water',
     BucketFilled = 'You filled a Water Bucket',
-    Tooclosetotown = 'You are too close to a town'
+    Tooclosetotown = 'You are too close to a town',
+    TooCloseToPlant = 'Too Close To another plant!'
 }
 
 --------------------------------- Town Locations ------------------------------------------------------------------------------------


### PR DESCRIPTION
This implements a distance checker between plants, not allowing you to plant another plant too close to another one. This is important because planting them on top of each other causes DB issues, and breaks. The distance check is done via a for loop running against the prop hashes listed in the config, and if you are near a prop with the hash listed in the config it notifies and does not plant the plant!